### PR TITLE
Recursive types

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,7 +1,7 @@
 use crate::{
     decimal::Decimal,
     duration::Duration,
-    schema::{FixedSchema, Schema, SchemaType},
+    schema::{Schema, SchemaType},
     types::Value,
     util::{safe_len, zag_i32, zag_i64},
     AvroResult, Error,

--- a/src/error.rs
+++ b/src/error.rs
@@ -256,13 +256,16 @@ pub enum Error {
     },
 
     #[error("Unexpected `type` {0} variant for `logicalType`")]
-    GetLogicalTypeVariant(serde_json::Value),
+    GetLogicalTypeVariant(String),
 
     #[error("No `type` field found for `logicalType`")]
     GetLogicalTypeField,
 
     #[error("logicalType must be a string")]
     GetLogicalTypeFieldType,
+
+    #[error("Duration must have a fixed length of 12 bytes.")]
+    GetDurationInvalidSize,
 
     #[error("Unknown complex type: {0}")]
     GetComplexType(serde_json::Value),

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,7 +105,11 @@ pub enum Error {
     GetU8(ValueKind),
 
     #[error("Precision {precision} too small to hold decimal values with {num_bytes} bytes. Should be at least {max_precision_for_num_bytes}")]
-    ComparePrecisionAndSize { precision: u64, max_precision_for_num_bytes: u64, num_bytes: u64 },
+    ComparePrecisionAndSize {
+        precision: u64,
+        max_precision_for_num_bytes: u64,
+        num_bytes: u64,
+    },
 
     #[error("Cannot convert length to i32: {1}")]
     ConvertLengthToI32(#[source] std::num::TryFromIntError, usize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,7 +569,7 @@
 //!           "type": {
 //!             "type": "fixed",
 //!             "size": 12,
-//!             "name": "duration"
+//!             "name": "duration12"
 //!           },
 //!           "logicalType": "duration"
 //!         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,57 +521,71 @@
 //!           "type": {
 //!             "type": "fixed",
 //!             "size": 2,
-//!             "name": "decimal"
-//!           },
-//!           "logicalType": "decimal",
-//!           "precision": 4,
-//!           "scale": 2
+//!             "name": "decimal",
+//!             "logicalType": "decimal",
+//!             "precision": 4,
+//!             "scale": 2
+//!           }
 //!         },
 //!         {
 //!           "name": "decimal_var",
-//!           "type": "bytes",
-//!           "logicalType": "decimal",
-//!           "precision": 10,
-//!           "scale": 3
+//!           "type": {
+//!             "type": "bytes",
+//!             "logicalType": "decimal",
+//!             "precision": 10,
+//!             "scale": 3
+//!           }
 //!         },
 //!         {
 //!           "name": "uuid",
-//!           "type": "string",
-//!           "logicalType": "uuid"
+//!           "type": {
+//!             "type": "string",
+//!             "logicalType": "uuid"
+//!           }
 //!         },
 //!         {
 //!           "name": "date",
-//!           "type": "int",
-//!           "logicalType": "date"
+//!           "type": {
+//!             "type": "int",
+//!             "logicalType": "date"
+//!           }
 //!         },
 //!         {
 //!           "name": "time_millis",
-//!           "type": "int",
-//!           "logicalType": "time-millis"
+//!           "type": {
+//!             "type": "int",
+//!             "logicalType": "time-millis"
+//!           }
 //!         },
 //!         {
 //!           "name": "time_micros",
-//!           "type": "long",
-//!           "logicalType": "time-micros"
+//!           "type": {
+//!             "type": "long",
+//!             "logicalType": "time-micros"
+//!           }
 //!         },
 //!         {
 //!           "name": "timestamp_millis",
-//!           "type": "long",
-//!           "logicalType": "timestamp-millis"
+//!           "type": {
+//!             "type": "long",
+//!             "logicalType": "timestamp-millis"
+//!           }
 //!         },
 //!         {
 //!           "name": "timestamp_micros",
-//!           "type": "long",
-//!           "logicalType": "timestamp-micros"
+//!           "type": {
+//!             "type": "long",
+//!             "logicalType": "timestamp-micros"
+//!           }
 //!         },
 //!         {
 //!           "name": "duration",
 //!           "type": {
 //!             "type": "fixed",
+//!             "logicalType": "duration",
 //!             "size": 12,
-//!             "name": "duration12"
-//!           },
-//!           "logicalType": "duration"
+//!             "name": "duration"
+//!           }
 //!         }
 //!       ]
 //!     }

--- a/src/schema/builder.rs
+++ b/src/schema/builder.rs
@@ -191,16 +191,14 @@ impl<'s> FixedBuilder<'s> {
 
 /// Builder that creates a decimal buffer in a schema
 #[derive(Default)]
-pub struct DecimalBuilder<'s> {
-    name: Option<Naming<'s>>,
+pub struct DecimalBuilder {
     size: Option<u64>,
     scale: Option<u64>,
 }
 
-impl<'s> DecimalBuilder<'s> {
+impl DecimalBuilder {
     pub fn new() -> Self {
         DecimalBuilder {
-            name: None,
             ..Default::default()
         }
     }
@@ -227,17 +225,9 @@ impl<'s> DecimalBuilder<'s> {
             size: self.size,
         };
 
-        match self.name {
-            Some(name) => {
-                let name_ref = name.into_ref(builder)?;
-                builder.add_type(name_ref, schema_datum)
-            }
-            None => builder.add_anon_type(schema_datum),
-        }
+        builder.add_anon_type(schema_datum)
     }
 }
-
-impl_opt_named_builder!(DecimalBuilder);
 
 pub struct EnumBuilder<'s> {
     name: Naming<'s>,
@@ -414,12 +404,8 @@ impl SchemaBuilder {
     logical_type_lookup!(timestamp_micros);
     logical_type_lookup!(duration);
 
-    pub fn decimal<'s>(&self) -> DecimalBuilder<'s> {
+    pub fn decimal<'s>(&self) -> DecimalBuilder {
         DecimalBuilder::new()
-    }
-
-    pub fn named_decimal<'s>(&self, name: &'s str) -> DecimalBuilder<'s> {
-        DecimalBuilder::name(name)
     }
 
     pub fn enumeration<'s>(&self, name: &'s str) -> EnumBuilder<'s> {

--- a/src/schema/data.rs
+++ b/src/schema/data.rs
@@ -23,9 +23,10 @@ pub(super) enum SchemaData {
     Enum(Documentation, Vec<String>),
     Fixed(usize),
     Decimal {
+        name: Option<NameRef>,
         precision: u64,
         scale: Option<u64>,
-        size: Option<u64>
+        size: Option<u64>,
     },
     Uuid,
     Date,
@@ -56,8 +57,14 @@ impl fmt::Debug for SchemaData {
                 f.debug_set().entries(syms).finish()
             }
             SchemaData::Fixed(size) => f.debug_tuple("fixed").field(size).finish(),
-            SchemaData::Decimal { precision, scale, size } => f
+            SchemaData::Decimal {
+                name,
+                precision,
+                scale,
+                size,
+            } => f
                 .debug_tuple("decimal")
+                .field(name)
                 .field(precision)
                 .field(&scale.unwrap_or(0))
                 .field(&size)
@@ -90,7 +97,7 @@ impl SchemaData {
             SchemaData::Record(_, _) => SchemaType::Record(RecordSchema(schema, name)),
             SchemaData::Enum(_, _) => SchemaType::Enum(EnumSchema(schema, name)),
             SchemaData::Fixed(_) => SchemaType::Fixed(FixedSchema(schema, name)),
-            SchemaData::Decimal{..} => SchemaType::Decimal(DecimalSchema(schema, name)),
+            SchemaData::Decimal { .. } => SchemaType::Decimal(DecimalSchema(schema, name)),
             SchemaData::Uuid => SchemaType::Uuid,
             SchemaData::Date => SchemaType::Date,
             SchemaData::TimeMillis => SchemaType::TimeMillis,

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -574,6 +574,10 @@ impl<'s> UnionSchema<'s> {
             // TODO shouldn't we also check for name and namespace?
             .find(|(_pos, schema_type)| {
                 let schema_kind = SchemaKind::from(*schema_type);
+                // A number default is always represented as a Value::Long. This check ensures that the right schema branch is found.
+                // TODO: Check what happens if kind is a logicalType and value resolves to a primitive? (uuid against string for instance)
+                // Also, if we have a schema with ["int", "long"] the int branch will be chosen. This probably cannot be fixed.
+
                 match (schema_kind, value) {
                     (SchemaKind::Int, &crate::types::Value::Long(v)) => {
                         v >= i32::min_value() as i64 && v <= i32::max_value() as i64

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -22,7 +22,6 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     collections::{HashMap, HashSet},
-    convert::TryInto,
     fmt,
     rc::Rc,
 };

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -428,6 +428,10 @@ impl<'s> DecimalSchema<'s> {
         self.0.root()
     }
 
+    pub fn name(&self) -> Name<'_> {
+        Name(self.0, self.1)
+    }
+
     pub fn is_fixed(&self) -> bool {
         self.size().is_some()
     }

--- a/src/schema/parse.rs
+++ b/src/schema/parse.rs
@@ -172,14 +172,12 @@ impl<'s> SchemaParser<'s> {
                 }
             }
 
-            "decimal" => {
-                if true {
-                    // TODO: Check fixed or decimal
+            "decimal" => match complex.get("type") {
+                Some(Value::String(typ)) if typ == "fixed" || typ == "bytes" => {
                     self.parse_decimal(complex)
-                } else {
-                    Err(Error::GetLogicalTypeFieldType)
                 }
-            }
+                _ => Err(Error::GetLogicalTypeFieldType),
+            },
 
             // As per spec, let it pass as a type since we dont understand the given logical
             _ => return Ok(schema),

--- a/src/schema/serialize.rs
+++ b/src/schema/serialize.rs
@@ -95,7 +95,15 @@ impl Serialize for OnceSchemaCell<FixedSchema<'_>> {
 impl Serialize for OnceSchemaCell<DecimalSchema<'_>> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "decimal")?;
+        if let Some(size) = self.actual.size() {
+            map.serialize_entry("type", "fixed")?;
+            map.serialize_entry("size", &size)?;
+            serialize_formal_name!(self.actual.name(), self.prev_ns.borrow(), map);
+        } else {
+            map.serialize_entry("type", "bytes")?;
+        }
+
+        map.serialize_entry("logicalType", "decimal")?;
         map.serialize_entry("precision", &self.actual.precision())?;
         map.serialize_entry("scale", &self.actual.scale())?;
         map.end()

--- a/src/schema/serialize.rs
+++ b/src/schema/serialize.rs
@@ -96,7 +96,6 @@ impl Serialize for OnceSchemaCell<DecimalSchema<'_>> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "decimal")?;
-        serialize_formal_name!(self.actual.name(), self.prev_ns.borrow(), map);
         map.serialize_entry("precision", &self.actual.precision())?;
         map.serialize_entry("scale", &self.actual.scale())?;
         map.end()

--- a/src/types.rs
+++ b/src/types.rs
@@ -477,7 +477,7 @@ impl Value {
                     precision,
                     num_bytes,
                     max_precision_for_num_bytes,
-                })
+                });
             }
         }
 
@@ -650,7 +650,7 @@ impl Value {
         };
         // Find the first match in the reader schema.
         let (_, inner) = schema
-            .resolve_union_schema(&v)
+            .resolve_union_schema(&v)
             .ok_or_else(|| Error::FindUnionVariant)?;
         Ok(Value::Union(Box::new(v.resolve(inner)?)))
     }
@@ -964,7 +964,7 @@ mod tests {
     fn resolve_decimal_bytes() {
         let value = Value::Decimal(Decimal::from(vec![1, 2]));
         let mut builder = Schema::builder();
-        let mut decimal = builder.named_decimal("test");
+        let mut decimal = builder.decimal();
         decimal.scale(2);
         let root = decimal.precision(4, &mut builder).unwrap();
         let expected = builder.build(root).unwrap();
@@ -975,7 +975,7 @@ mod tests {
     #[test]
     fn resolve_decimal_invalid_scale() {
         let mut builder = Schema::builder();
-        let mut decimal = builder.named_decimal("test");
+        let mut decimal = builder.decimal();
         decimal.scale(3);
         let root = decimal.precision(2, &mut builder);
         assert!(root.is_err())
@@ -985,10 +985,7 @@ mod tests {
     fn resolve_decimal_invalid_precision_for_length() {
         let value = Value::Decimal(Decimal::from((1u8..=8u8).rev().collect::<Vec<_>>()));
         let mut builder = Schema::builder();
-        let root = builder
-            .named_decimal("test")
-            .precision(1, &mut builder)
-            .unwrap();
+        let root = builder.decimal().precision(1, &mut builder).unwrap();
         let expected = builder.build(root).unwrap();
         assert!(value.resolve(expected.root()).is_err());
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -333,7 +333,7 @@ impl Value {
             (&Value::Float(_), SchemaType::Float) => true,
             (&Value::Double(_), SchemaType::Double) => true,
             (&Value::Bytes(_), SchemaType::Bytes) => true,
-            (&Value::Bytes(_), SchemaType::Decimal(dec)) => true,
+            (&Value::Bytes(_), SchemaType::Decimal(_)) => true,
             (&Value::String(_), SchemaType::String) => true,
             (&Value::String(_), SchemaType::Uuid) => true,
             //TODO: do we need to use name here for the fixed?

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -332,7 +332,7 @@ pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Ve
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{duration::*, decimal::Decimal, types::Record, util::zig_i64};
+    use crate::{decimal::Decimal, duration::*, types::Record, util::zig_i64};
     use serde::{Deserialize, Serialize};
 
     const AVRO_OBJECT_HEADER_LEN: usize = AVRO_OBJECT_HEADER.len();
@@ -498,7 +498,7 @@ mod tests {
         let size = 30;
 
         let mut builder = Schema::builder();
-        let mut decimal = builder.named_decimal("decimal");
+        let mut decimal = builder.decimal();
         decimal.scale(5);
         decimal.size(size as u64);
         let root = decimal.precision(20, &mut builder)?;
@@ -506,7 +506,7 @@ mod tests {
 
         let value = vec![0u8; size];
         logical_type_test(
-            r#"{"type": "fixed", "size": 30, "name": "decimal", "logicalType": "decimal", "precision": 20, "scale": 5}"#,
+            r#"{"name": "fixed_decimal", "type": "fixed", "size": 30, "logicalType": "decimal", "precision": 20, "scale": 5}"#,
             &expected.root(),
             Value::Decimal(Decimal::from(value.clone())),
             &expected,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -498,7 +498,7 @@ mod tests {
         let size = 30;
 
         let mut builder = Schema::builder();
-        let mut decimal = builder.decimal();
+        let mut decimal = builder.named_decimal("fixed_decimal");
         decimal.scale(5);
         decimal.size(size as u64);
         let root = decimal.precision(20, &mut builder)?;

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -39,12 +39,14 @@ lazy_static! {
         (r#""boolean""#, "true", Value::Boolean(true)),
         (r#""string""#, r#""foo""#, Value::String("foo".to_string())),
         // TODO: (#96) investigate why this is failing
-        //(r#""bytes""#, r#""\u00FF\u00FF""#, Value::Bytes(vec![0xff, 0xff])),
+        // > Reason is that the 00FF unicode char is encoded as a \xC3 \xBF which is not converted back to \xFF.
+        // (r#""bytes""#, r#""\u00FF\u00FF""#, Value::Bytes(vec![0xff, 0xff])),
         (r#""int""#, "5", Value::Int(5)),
         (r#""long""#, "5", Value::Long(5)),
         (r#""float""#, "1.1", Value::Float(1.1)),
         (r#""double""#, "1.1", Value::Double(1.1)),
         // TODO: (#96) investigate why this is failing
+        // Probably same as bytes
         //(r#"{"type": "fixed", "name": "F", "size": 2}"#, r#""\u00FF\u00FF""#, Value::Bytes(vec![0xff, 0xff])),
         (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
         (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -45,6 +45,11 @@ lazy_static! {
         (r#""long""#, "5", Value::Long(5)),
         (r#""float""#, "1.1", Value::Float(1.1)),
         (r#""double""#, "1.1", Value::Double(1.1)),
+
+        (r#"{"type": "string", "logicalType": "uuid"}"#, r#""64a8cd70-28e3-4fc4-9c7f-db18d8cac512""#, Value::Uuid(uuid::Uuid::from_str("64a8cd70-28e3-4fc4-9c7f-db18d8cac512").unwrap())),
+        (r#"{"type": "long", "logicalType": "timestamp-millis"}"#, "123456789", Value::TimestampMillis(123456789)),
+
+
         // TODO: (#96) investigate why this is failing
         // Probably same as bytes
         //(r#"{"type": "fixed", "name": "F", "size": 2}"#, r#""\u00FF\u00FF""#, Value::Bytes(vec![0xff, 0xff])),
@@ -52,8 +57,9 @@ lazy_static! {
         (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
         (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
         (r#"["int", "null"]"#, "5", Value::Union(Box::new(Value::Int(5)))),
-        // TODO: (#91) investigate why this is failing
-        //(r#"[{"type": {"type": "string", "logicalType": "uuid"}}, "null"]"#, r#""64a8cd70-28e3-4fc4-9c7f-db18d8cac512""#, Value::Union(Box::new(Value::Uuid(uuid::Uuid::from_str("64a8cd70-28e3-4fc4-9c7f-db18d8cac512").unwrap())))),
+
+        (r#"[{"type": "string", "logicalType": "uuid"}, "null"]"#, r#""64a8cd70-28e3-4fc4-9c7f-db18d8cac512""#, Value::Union(Box::new(Value::Uuid(uuid::Uuid::from_str("64a8cd70-28e3-4fc4-9c7f-db18d8cac512").unwrap())))),
+        (r#"[{"type": "long", "logicalType": "timestamp-millis"}, "null"]"#, "123456789", Value::Union(Box::new(Value::TimestampMillis(123456789)))),
 
         (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
     ];

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,5 +1,5 @@
 //! Port of https://github.com/apache/avro/blob/release-1.9.1/lang/py/test/test_io.py
-use std::io::Cursor;
+use std::{io::Cursor, str::FromStr};
 
 use avro_rs::{from_avro_datum, to_avro_datum, types::Value, Error, Schema};
 use lazy_static::lazy_static;
@@ -52,6 +52,9 @@ lazy_static! {
         (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
         (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
         (r#"["int", "null"]"#, "5", Value::Union(Box::new(Value::Int(5)))),
+        // TODO: (#91) investigate why this is failing
+        //(r#"[{"type": {"type": "string", "logicalType": "uuid"}}, "null"]"#, r#""64a8cd70-28e3-4fc4-9c7f-db18d8cac512""#, Value::Union(Box::new(Value::Uuid(uuid::Uuid::from_str("64a8cd70-28e3-4fc4-9c7f-db18d8cac512").unwrap())))),
+
         (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
     ];
 

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -35,22 +35,22 @@ lazy_static! {
     ];
 
     static ref DEFAULT_VALUE_EXAMPLES: Vec<(&'static str, &'static str, Value)> = vec![
-// (r#""null""#, "null", Value::Null),
-// (r#""boolean""#, "true", Value::Boolean(true)),
-// (r#""string""#, r#""foo""#, Value::String("foo".to_string())),
+        (r#""null""#, "null", Value::Null),
+        (r#""boolean""#, "true", Value::Boolean(true)),
+        (r#""string""#, r#""foo""#, Value::String("foo".to_string())),
         // TODO: (#96) investigate why this is failing
         //(r#""bytes""#, r#""\u00FF\u00FF""#, Value::Bytes(vec![0xff, 0xff])),
-// (r#""int""#, "5", Value::Int(5)),
-// (r#""long""#, "5", Value::Long(5)),
-// (r#""float""#, "1.1", Value::Float(1.1)),
-// (r#""double""#, "1.1", Value::Double(1.1)),
+        (r#""int""#, "5", Value::Int(5)),
+        (r#""long""#, "5", Value::Long(5)),
+        (r#""float""#, "1.1", Value::Float(1.1)),
+        (r#""double""#, "1.1", Value::Double(1.1)),
         // TODO: (#96) investigate why this is failing
         //(r#"{"type": "fixed", "name": "F", "size": 2}"#, r#""\u00FF\u00FF""#, Value::Bytes(vec![0xff, 0xff])),
-// (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
-// (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
-// (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
+        (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
+        (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
+        (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
         (r#"["int", "null"]"#, "5", Value::Union(Box::new(Value::Int(5)))),
-//        (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
+        (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
     ];
 
     static ref LONG_RECORD_SCHEMA: Schema = Schema::parse_str(r#"

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -35,22 +35,22 @@ lazy_static! {
     ];
 
     static ref DEFAULT_VALUE_EXAMPLES: Vec<(&'static str, &'static str, Value)> = vec![
-        (r#""null""#, "null", Value::Null),
-        (r#""boolean""#, "true", Value::Boolean(true)),
-        (r#""string""#, r#""foo""#, Value::String("foo".to_string())),
+// (r#""null""#, "null", Value::Null),
+// (r#""boolean""#, "true", Value::Boolean(true)),
+// (r#""string""#, r#""foo""#, Value::String("foo".to_string())),
         // TODO: (#96) investigate why this is failing
         //(r#""bytes""#, r#""\u00FF\u00FF""#, Value::Bytes(vec![0xff, 0xff])),
-        (r#""int""#, "5", Value::Int(5)),
-        (r#""long""#, "5", Value::Long(5)),
-        (r#""float""#, "1.1", Value::Float(1.1)),
-        (r#""double""#, "1.1", Value::Double(1.1)),
+// (r#""int""#, "5", Value::Int(5)),
+// (r#""long""#, "5", Value::Long(5)),
+// (r#""float""#, "1.1", Value::Float(1.1)),
+// (r#""double""#, "1.1", Value::Double(1.1)),
         // TODO: (#96) investigate why this is failing
         //(r#"{"type": "fixed", "name": "F", "size": 2}"#, r#""\u00FF\u00FF""#, Value::Bytes(vec![0xff, 0xff])),
-        (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
-        (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
-        (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
+// (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
+// (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
+// (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
         (r#"["int", "null"]"#, "5", Value::Union(Box::new(Value::Int(5)))),
-        (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
+//        (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
     ];
 
     static ref LONG_RECORD_SCHEMA: Schema = Schema::parse_str(r#"

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -707,10 +707,55 @@ fn test_parse_list_recursive_type_error() {
             {"name": "field_one", "type": "A"}
         ]
     }"#;
+    let schema_composite_1 = r#"{
+        "name": "A",
+        "type": "record",
+        "fields": [
+            { "name": "field_one",
+            "type": {
+                "name": "B",
+                "type": "record",
+                "fields": [
+                    {"name": "field_one", "type": "A"}
+                    ]
+                }
+            }
+        ]
+
+    }"#;
+    let schema_composite_2 = r#"{
+        "name": "B",
+        "type": "record",
+        "fields": [
+            { "name": "field_one",
+            "type": {
+                "name": "A",
+                "type": "record",
+                "fields": [
+                    {"name": "field_one", "type": "B"}
+                    ]
+                }
+            }
+        ]
+
+    }"#;
     let schema_strs_first = [schema_str_1, schema_str_2];
     let schema_strs_second = [schema_str_2, schema_str_1];
-    let _ = Schema::parse_list(&schema_strs_first).expect_err("Test failed");
-    let _ = Schema::parse_list(&schema_strs_second).expect_err("Test failed");
+
+    let schemas_first = Schema::parse_list(&schema_strs_first).expect("Test failed");
+    let schemas_second = Schema::parse_list(&schema_strs_second).expect("Test failed");
+
+    let parsed_composite_1 = Schema::parse_str(&schema_composite_1).expect("Test failed");
+    let parsed_composite_2 = Schema::parse_str(&schema_composite_2).expect("Test failed");
+
+    assert_eq!(
+        schemas_first,
+        vec!(parsed_composite_1.clone(), parsed_composite_2.clone())
+    );
+    assert_eq!(
+        schemas_second,
+        vec!(parsed_composite_2.clone(), parsed_composite_1.clone())
+    );
 }
 
 #[test]

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -425,32 +425,24 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
 
 const DECIMAL_LOGICAL_TYPE_ATTRIBUTES: &[(&str, bool)] = &[
     // TODO: (#93) support logical types and attributes and uncomment
-    // (
-    //     r#"{
-    //         "type": "fixed",
-    //         "logicalType": "decimal",
-    //         "name": "TestDecimal",
-    //         "precision": 4,
-    //         "scale": 2,
-    //         "size": 2
-    //     }"#,
-    //     true,
-    // ),
-    // (
-    //     r#"{
-    //         "type": "bytes",
-    //         "logicalType": "decimal",
-    //         "precision": 4
-    //     }"#,
-    //     true,
-    // ),
     (
         r#"{
-            "type": "string",
+            "type": "fixed",
+            "logicalType": "decimal",
+            "name": "TestDecimal",
+            "precision": 4,
+            "scale": 2,
+            "size": 2
+        }"#,
+        true,
+    ),
+    (
+        r#"{
+            "type": "bytes",
             "logicalType": "decimal",
             "precision": 4
         }"#,
-        false,
+        true,
     ),
 ];
 
@@ -600,6 +592,8 @@ fn test_parse() {
 fn test_valid_cast_to_string_after_parse() {
     for (raw_schema, _) in VALID_EXAMPLES.iter() {
         let schema = Schema::parse_str(raw_schema).unwrap();
+
+        println!("{:?}", schema.to_string());
         Schema::parse_str(schema.canonical_form().as_str()).unwrap();
     }
 }

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -424,28 +424,34 @@ const DECIMAL_LOGICAL_TYPE: &[(&str, bool)] = &[
 ];
 
 const DECIMAL_LOGICAL_TYPE_ATTRIBUTES: &[(&str, bool)] = &[
-    /*
     // TODO: (#93) support logical types and attributes and uncomment
+    // (
+    //     r#"{
+    //         "type": "fixed",
+    //         "logicalType": "decimal",
+    //         "name": "TestDecimal",
+    //         "precision": 4,
+    //         "scale": 2,
+    //         "size": 2
+    //     }"#,
+    //     true,
+    // ),
+    // (
+    //     r#"{
+    //         "type": "bytes",
+    //         "logicalType": "decimal",
+    //         "precision": 4
+    //     }"#,
+    //     true,
+    // ),
     (
         r#"{
-            "type": "fixed",
-            "logicalType": "decimal",
-            "name": "TestDecimal",
-            "precision": 4,
-            "scale": 2,
-            "size": 2
-        }"#,
-        true
-    ),
-    (
-        r#"{
-            "type": "bytes",
+            "type": "string",
             "logicalType": "decimal",
             "precision": 4
         }"#,
-        true
+        false,
     ),
-    */
 ];
 
 const DATE_LOGICAL_TYPE: &[(&str, bool)] = &[


### PR DESCRIPTION
This fixes all (currently uncommented) tests. I was able to uncomment a few more but not all of them.

The fix in schema::find_schema for the union test you mentioned is rather ugly. 

The parse_list method introduced earlier was broken for recursive types and is fixed now.
Logical types did not check if they annotate the correct base type. 
Added (optional) name to Decimal type so it serializes to the correct schema.
Fixed resolving of default values for logical types in unions.